### PR TITLE
Fix incorrect cast

### DIFF
--- a/src/Models/TimeEntry.php
+++ b/src/Models/TimeEntry.php
@@ -13,7 +13,7 @@ class TimeEntry extends Model
      * @var array
      */
     protected $casts = [
-        'reference' => 'object',
+        'external_reference' => 'object',
         'is_locked' => 'boolean',
         'is_closed' => 'boolean',
         'is_billed' => 'boolean',


### PR DESCRIPTION
`reference` is actually `external_reference`, so this leads to an array to string conversion error if `external_reference` data is present.